### PR TITLE
Define git commit messages guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ These guidelines are based on [Building a strong community Github documentation]
 	* [Multiple Issue Templates Over Single Issue Template](#multiple-issue-template-over-single-issue-template)
 	* [Issue & Pull Request Expectation](#issue--pull-request-expectation)
 	* [Promoting A High Contribution Quality](#promoting-a-high-contribution-quality)
-	* [Git Commit Messages](#git-commit-messages)
+* [Git Commit Messages](#git-commit-messages)
+	* [Short Commit Messages](#short-commit-messages)
+	* [Issue Reference](#issue-reference)
+	* [Commit Nature](#commit-nature)
 * [Milestone](#milestone)
 * [Label](#label)
 * [CHANGELOG](#changelog)
@@ -94,11 +97,11 @@ Templates should promote a high contribution quality by referring [contributing 
 ...
 ```
 
-### Git Commit Messages
+## Git Commit Messages
 
-#### Content
+### Short Commit Messages
 
-Git Commit messages should always be clear about what has been done. It should be written at the present tense and imperative Mood.
+Git commit messages should help reviewers to quickly understand what has been done. It should be short, clear and written at the present tense and imperative mood.
 
 **Preferred:**
 ```markdown
@@ -112,9 +115,9 @@ Git Commit messages should always be clear about what has been done. It should b
 - Updates navigation storyboard.
 ```
 
-#### Reference
+### Issue Reference
 
-Git Commit messages should reference issues at the end.
+Referencing issue in git commit messages should help anyone to track progress on a specific issue. Git commit messages should always reference issues at the end.
 
 **Preferred:**
 ```markdown
@@ -128,23 +131,22 @@ Git Commit messages should reference issues at the end.
 - #1024 Remove unused ViewController method.
 ```
 
-#### Emojis
+### Commit Nature
 
-For clear visual identification start the commit message with an applicable emoji:
+Emojis should help reviewers to quickly and visually identify the nature of the commit. For clear visual identification start the commit message with an applicable emoji:
 
-   - :art: `:art:` when improving the format/structure of the code
-   - :racehorse: `:racehorse:` when improving performance
-   - :non-potable_water: `:non-potable_water:` when plugging memory leaks
-   - :memo: `:memo:` when writing docs
-   - :bug: `:bug:` when fixing a bug
-   - :fire: `:fire:` when removing code or files
-   - :green_heart: `:green_heart:` when fixing the CI build
-   - :white_check_mark: `:white_check_mark:` when adding tests
-   - :lock: `:lock:` when dealing with security
-   - :arrow_up: `:arrow_up:` when upgrading dependencies
-   - :arrow_down: `:arrow_down:` when downgrading dependencies
-   - :shirt: `:shirt:` when removing linter warnings
-
+- :art: `:art:` when improving the format/structure of the code
+- :racehorse: `:racehorse:` when improving performance
+- :non-potable_water: `:non-potable_water:` when plugging memory leaks
+- :memo: `:memo:` when writing docs
+- :bug: `:bug:` when fixing a bug
+- :fire: `:fire:` when removing code or files
+- :green_heart: `:green_heart:` when fixing the CI build
+- :white_check_mark: `:white_check_mark:` when adding tests
+- :lock: `:lock:` when dealing with security
+- :arrow_up: `:arrow_up:` when upgrading dependencies
+- :arrow_down: `:arrow_down:` when downgrading dependencies
+- :shirt: `:shirt:` when removing linter warnings
 
 ## Milestone
 

--- a/README.md
+++ b/README.md
@@ -132,18 +132,18 @@ Git Commit messages should reference issues at the end.
 
 For clear visual identification start the commit message with an applicable emoji:
 
-    * :art: `:art:` when improving the format/structure of the code
-    * :racehorse: `:racehorse:` when improving performance
-    * :non-potable_water: `:non-potable_water:` when plugging memory leaks
-    * :memo: `:memo:` when writing docs
-    * :bug: `:bug:` when fixing a bug
-    * :fire: `:fire:` when removing code or files
-    * :green_heart: `:green_heart:` when fixing the CI build
-    * :white_check_mark: `:white_check_mark:` when adding tests
-    * :lock: `:lock:` when dealing with security
-    * :arrow_up: `:arrow_up:` when upgrading dependencies
-    * :arrow_down: `:arrow_down:` when downgrading dependencies
-    * :shirt: `:shirt:` when removing linter warnings
+   - :art: `:art:` when improving the format/structure of the code
+   - :racehorse: `:racehorse:` when improving performance
+   - :non-potable_water: `:non-potable_water:` when plugging memory leaks
+   - :memo: `:memo:` when writing docs
+   - :bug: `:bug:` when fixing a bug
+   - :fire: `:fire:` when removing code or files
+   - :green_heart: `:green_heart:` when fixing the CI build
+   - :white_check_mark: `:white_check_mark:` when adding tests
+   - :lock: `:lock:` when dealing with security
+   - :arrow_up: `:arrow_up:` when upgrading dependencies
+   - :arrow_down: `:arrow_down:` when downgrading dependencies
+   - :shirt: `:shirt:` when removing linter warnings
 
 
 ## Milestone

--- a/README.md
+++ b/README.md
@@ -99,9 +99,11 @@ Templates should promote a high contribution quality by referring [contributing 
 
 ## Git Commit Messages
 
+Git commit messages should help reviewers to do better reviews.
+
 ### Short Commit Messages
 
-Git commit messages should help reviewers to quickly understand what has been done. It should be short, clear and written at the present tense and imperative mood.
+Short commit messages should help reviewers to quickly understand what has been done. It should be short, clear and written at the present tense and imperative mood.
 
 **Preferred:**
 ```markdown

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ These guidelines are based on [Building a strong community Github documentation]
 	* [Multiple Issue Templates Over Single Issue Template](#multiple-issue-template-over-single-issue-template)
 	* [Issue & Pull Request Expectation](#issue--pull-request-expectation)
 	* [Promoting A High Contribution Quality](#promoting-a-high-contribution-quality)
+	* [Git Commit Messages](#git-commit-messages)
 * [Milestone](#milestone)
 * [Label](#label)
 * [CHANGELOG](#changelog)
@@ -92,6 +93,58 @@ Templates should promote a high contribution quality by referring [contributing 
 
 ...
 ```
+
+### Git Commit Messages
+
+#### Content
+
+Git Commit messages should always be clear about what has been done. It should be written at the present tense and imperative Mood.
+
+**Preferred:**
+```markdown
+- Add get user feature.
+- Update navigation storyboard.
+```
+
+**Not Preferred:**
+```markdown
+- Added get user feature.
+- Updates navigation storyboard.
+```
+
+#### Reference
+
+Git Commit messages should reference issues at the end.
+
+**Preferred:**
+```markdown
+- Improve cache management. Related to #42.
+- Remove unused ViewController method. Related to #1024.
+```
+
+**Not Preferred:**
+```markdown
+- Improve cache management.
+- #1024 Remove unused ViewController method.
+```
+
+#### Emojis
+
+For clear visual identification start the commit message with an applicable emoji:
+
+    * :art: `:art:` when improving the format/structure of the code
+    * :racehorse: `:racehorse:` when improving performance
+    * :non-potable_water: `:non-potable_water:` when plugging memory leaks
+    * :memo: `:memo:` when writing docs
+    * :bug: `:bug:` when fixing a bug
+    * :fire: `:fire:` when removing code or files
+    * :green_heart: `:green_heart:` when fixing the CI build
+    * :white_check_mark: `:white_check_mark:` when adding tests
+    * :lock: `:lock:` when dealing with security
+    * :arrow_up: `:arrow_up:` when upgrading dependencies
+    * :arrow_down: `:arrow_down:` when downgrading dependencies
+    * :shirt: `:shirt:` when removing linter warnings
+
 
 ## Milestone
 

--- a/README.md
+++ b/README.md
@@ -159,3 +159,5 @@ Emojis should help reviewers to quickly and visually identify the nature of the 
 ## CONTRIBUTING.md
 
 ## Resources
+
+- [Atom CONTRIBUTING.md](https://github.com/atom/atom/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
## Goals :soccer:
Define GitHub guidelines in terms of commit messages.

## Inspiration :bulb:
- Atom [CONTIBUTING.md](https://github.com/atom/atom/blob/master/CONTRIBUTING.md)