### PR TITLE
Add git commit message hook

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+message_file = ARGV[0]
+message = File.read(message_file)
+
+$grammar_regex = Regexp.new('^:(memo|art|racehorse|non-potable_water|bug|fire|green_heart|white_check_mark|lock|arrow_up|arrow_down|shirt):\s[A-Z][\w\d\s]*[\w\d]\.(\s(Related to)[#\w\d\s]*[\w\d]\.)?$')
+
+if !$grammar_regex.match(message)
+  puts "Your message does not match with the rules defined in the CONTRIBUTING.md."
+  exit 1
+end


### PR DESCRIPTION
## Goals :soccer:

Enforce contribution quality by checking commit messages.

Contributors should run the following shell command:

```bash
git config core.hooksPath .githooks
```

## Inspiration :bulb:

- [Two Ways to Share Git Hooks with Your Team]( https://www.viget.com/articles/two-ways-to-share-git-hooks-with-your-team/)